### PR TITLE
Use php instead of phpdbg for coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ tests:
 
 .PHONY: coverage
 coverage:
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
+	vendor/bin/tester -s -p php --colors 1 -C --coverage ./coverage.xml --coverage-src ./app tests
 
 .PHONY: dev
 dev:


### PR DESCRIPTION
## Summary
- replace `-p phpdbg` with `-p php` in the `coverage` Makefile target
- align the coverage command with environments where `phpdbg` is unavailable

## Motivation
- `phpdbg` is no longer needed for this coverage command and can break coverage runs when it is missing
- relates to contributte/contributte#73

## Testing
- [x] `make -n coverage`
- [ ] CI passes