### PR TITLE
Composer: require PHP >=8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "type": "project",
   "require": {
-    "php": "^8.4",
+    "php": ">=8.4",
     "contributte/kernel": "^0.2",
     "contributte/framex": "^0.3",
     "contributte/utils": "^0.7"


### PR DESCRIPTION
Updates the Composer PHP requirement from ^8.4 to >=8.4.